### PR TITLE
ci(release): remove fetch-tags input from checkout action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
           token: ${{ secrets.COATL_BOT_GH_TOKEN }}
 
       - run: |


### PR DESCRIPTION
fetch-depth = 0 indicates all history for all branches and tags
