### PR TITLE
refactor: use valid SPDX license expression

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,18 +4,25 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
-end_of_line = lf
 charset = utf-8
+end_of_line = lf
 trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab
+insert_final_newline = false
 
-[*.json]
+[*.{json}]
 indent_size = 2
+indent_style = space
+insert_final_newline = false
 
 [*.{md,toml,yaml,yml}]
 indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.{py}]
+indent_size = 4
+indent_style = space
 insert_final_newline = true

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  pre-commit-autoupdate:
+  autoupdate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -26,13 +26,13 @@ jobs:
           path: deps
 
       - name: Update copyright year
-        if: ${{ github.event.schedule == '0 0 1 1 *' }}
+        if: ${{ github.event.schedule == '0 0 1 1 *'}}
         run: |
           current_year=$(date +'%Y')
 
           echo "current_year: $current_year"
 
-          sed -i 's/default: [0-9]\{4\}/default: $current_year/' copier.yml
+          sed -i "s/default: [0-9]\{4\}/default: $current_year/" copier.yml
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -50,9 +50,11 @@ jobs:
             --repo https://github.com/aio-libs/sort-all \
             --repo https://github.com/bwhmather/ssort \
             --repo https://github.com/psf/black \
+            --repo https://github.com/hakancelikdev/unimport \
             --repo https://github.com/PyCQA/isort \
             --repo https://github.com/PyCQA/docformatter \
-            --repo https://github.com/PyCQA/pydocstyle
+            --repo https://github.com/PyCQA/pydocstyle \
+            --repo https://github.com/jsh9/pydoclint
         working-directory: ./ignition-project
 
       - name: Update jython-package
@@ -61,9 +63,11 @@ jobs:
             --repo https://github.com/aio-libs/sort-all \
             --repo https://github.com/bwhmather/ssort \
             --repo https://github.com/psf/black \
+            --repo https://github.com/hakancelikdev/unimport \
             --repo https://github.com/PyCQA/isort \
             --repo https://github.com/PyCQA/docformatter \
-            --repo https://github.com/PyCQA/pydocstyle
+            --repo https://github.com/PyCQA/pydocstyle \
+            --repo https://github.com/jsh9/pydoclint
         working-directory: ./jython-package
 
       - name: Update python2-package
@@ -72,9 +76,11 @@ jobs:
             --repo https://github.com/aio-libs/sort-all \
             --repo https://github.com/bwhmather/ssort \
             --repo https://github.com/psf/black \
+            --repo https://github.com/hakancelikdev/unimport \
             --repo https://github.com/PyCQA/isort \
             --repo https://github.com/PyCQA/docformatter \
-            --repo https://github.com/PyCQA/pydocstyle
+            --repo https://github.com/PyCQA/pydocstyle \
+            --repo https://github.com/jsh9/pydoclint
         working-directory: ./python2-package
 
       - name: Update python3-stubs

--- a/copier.yml
+++ b/copier.yml
@@ -74,26 +74,26 @@ github_repo:
 project_license:
   type: str
   help: Choose a license
-  default: MIT License
+  default: MIT
   choices:
-    Apache: Apache Software License
-    GPLv3: GNU General Public License v3 (GPLv3)
-    ISC: ISC License (ISCL)
-    MIT: MIT License
-    None: None
+    Apache-2.0: Apache-2.0
+    GPL-3.0: GPL-3.0
+    ISC: ISC
+    MIT: MIT
+    Proprietary: LicenseRef-Proprietary
     Unlicense: Unlicense
 
 copyright_holder:
   type: str
   help: Who is the copyright holder?
   default: "{{ author_fullname }}"
-  when: "{{ project_license not in ['None', 'Unlicense'] }}"
+  when: "{{ project_license not in ['Unlicense'] }}"
 
 copyright_year:
   type: str
   help: Copyright year(s)
-  default: $current_year
-  when: "{{ project_license not in ['None', 'Unlicense'] }}"
+  default: 2025
+  when: "{{ project_license not in ['Unlicense'] }}"
 
 project_inheritable:
   type: bool
@@ -110,7 +110,7 @@ use_sourcery:
 upload_registry:
   type: bool
   help: Will this project be uploaded to a Python repository? (E.g. PyPI, Azure Artifacts)
-  default: "{{ project_license != 'None' }}"
+  default: "{{ project_license != 'LicenseRef-Proprietary' }}"
   when: "{{ project_type != 'ignition-project' }}"
 
 registry_url:

--- a/ignition-project/.editorconfig
+++ b/ignition-project/.editorconfig
@@ -6,13 +6,19 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
 trim_trailing_whitespace = true
 
-[*.json]
+[*.{json}]
 indent_size = 2
+indent_style = space
+insert_final_newline = false
 
-[*.{md,yaml,yml,toml}]
+[*.{md,toml,yaml,yml}]
 indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.{py}]
+indent_size = 4
+indent_style = space
 insert_final_newline = true

--- a/ignition-project/.github/workflows/ci.yml
+++ b/ignition-project/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v5
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v5

--- a/ignition-project/LICENSE.jinja
+++ b/ignition-project/LICENSE.jinja
@@ -1,4 +1,4 @@
-{%- if project_license == 'Apache Software License' -%}
+{%- if project_license == 'Apache-2.0' -%}
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -200,7 +200,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-{%- elif project_license == 'GNU General Public License v3 (GPLv3)' -%}
+{%- elif project_license == 'GPL-3.0' -%}
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -875,7 +875,7 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <https://www.gnu.org/licenses/why-not-lgpl.html>.
-{%- elif project_license == 'ISC License (ISCL)' -%}
+{%- elif project_license == 'ISC' -%}
 ISC License
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
@@ -891,8 +891,8 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
-{%- elif project_license == 'MIT License' -%}
-MIT License
+{%- elif project_license == 'MIT' -%}
+MIT
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
 

--- a/jython-package/.editorconfig
+++ b/jython-package/.editorconfig
@@ -4,20 +4,25 @@
 root = true
 
 [*]
+charset = utf-8
 end_of_line = lf
 trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab
+insert_final_newline = false
+
+[*.{json}]
+indent_size = 2
+indent_style = space
+insert_final_newline = false
 
 [*.{md,toml,yaml,yml}]
-indent_style = space
 indent_size = 2
-insert_final_newline = true
-x-soft-wrap-text = true
-
-[*.py]
-charset = utf-8
 indent_style = space
 insert_final_newline = true
+
+[*.{py}]
 indent_size = 4
+indent_style = space
+insert_final_newline = true

--- a/jython-package/.github/workflows/ci.yml
+++ b/jython-package/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v5
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v5

--- a/jython-package/.github/workflows/pr-build.yml
+++ b/jython-package/.github/workflows/pr-build.yml
@@ -18,4 +18,4 @@ jobs:
 
   tox:
     needs: jython
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5

--- a/jython-package/.github/workflows/{% if upload_registry %}publish.yml{% endif %}.jinja
+++ b/jython-package/.github/workflows/{% if upload_registry %}publish.yml{% endif %}.jinja
@@ -7,13 +7,13 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v5
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v5
 
   jython:
     needs: pylint
@@ -21,11 +21,11 @@ jobs:
 
   tox:
     needs: jython
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5
 
   pypi-publish:
     needs: tox
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v5
     with:
       python-version: '2.7'
       {%- if registry_url != 'https://upload.pypi.org/legacy/' %}

--- a/jython-package/LICENSE.jinja
+++ b/jython-package/LICENSE.jinja
@@ -1,4 +1,4 @@
-{%- if project_license == 'Apache Software License' -%}
+{%- if project_license == 'Apache-2.0' -%}
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -200,7 +200,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-{%- elif project_license == 'GNU General Public License v3 (GPLv3)' -%}
+{%- elif project_license == 'GPL-3.0' -%}
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -875,7 +875,7 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <https://www.gnu.org/licenses/why-not-lgpl.html>.
-{%- elif project_license == 'ISC License (ISCL)' -%}
+{%- elif project_license == 'ISC' -%}
 ISC License
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
@@ -891,8 +891,8 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
-{%- elif project_license == 'MIT License' -%}
-MIT License
+{%- elif project_license == 'MIT' -%}
+MIT
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
 
@@ -938,4 +938,8 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
+{%- elif project_license == 'LicenseRef-Proprietary' -%}
+Copyright (c) {{ copyright_year }} {{ copyright_holder }}. All rights reserved.
+
+Please contact {{ author_email }} for licensing terms.
 {%- endif -%}

--- a/python2-package/.editorconfig
+++ b/python2-package/.editorconfig
@@ -6,10 +6,19 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
-insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{json}]
+indent_size = 2
+indent_style = space
+insert_final_newline = false
 
 [*.{md,toml,yaml,yml}]
 indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.{py}]
+indent_size = 4
+indent_style = space
+insert_final_newline = true

--- a/python2-package/.github/workflows/ci.yml
+++ b/python2-package/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v5
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v5

--- a/python2-package/.github/workflows/pr-build.yml
+++ b/python2-package/.github/workflows/pr-build.yml
@@ -14,4 +14,4 @@ on:
 
 jobs:
   tox:
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5

--- a/python2-package/.github/workflows/{% if upload_registry %}publish.yml{% endif %}.jinja
+++ b/python2-package/.github/workflows/{% if upload_registry %}publish.yml{% endif %}.jinja
@@ -7,13 +7,13 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v5
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v5
 
   jython:
     needs: pylint
@@ -21,11 +21,11 @@ jobs:
 
   tox:
     needs: jython
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5
 
   pypi-publish:
     needs: tox
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v5
     with:
       python-version: '2.7'
       {%- if registry_url != 'https://upload.pypi.org/legacy/' %}

--- a/python2-package/LICENSE.jinja
+++ b/python2-package/LICENSE.jinja
@@ -1,4 +1,4 @@
-{%- if project_license == 'Apache Software License' -%}
+{%- if project_license == 'Apache-2.0' -%}
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -200,7 +200,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-{%- elif project_license == 'GNU General Public License v3 (GPLv3)' -%}
+{%- elif project_license == 'GPL-3.0' -%}
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -875,7 +875,7 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <https://www.gnu.org/licenses/why-not-lgpl.html>.
-{%- elif project_license == 'ISC License (ISCL)' -%}
+{%- elif project_license == 'ISC' -%}
 ISC License
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
@@ -891,8 +891,8 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
-{%- elif project_license == 'MIT License' -%}
-MIT License
+{%- elif project_license == 'MIT' -%}
+MIT
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
 

--- a/python3-stubs/.editorconfig
+++ b/python3-stubs/.editorconfig
@@ -6,13 +6,14 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
-insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.{py,pyi}]
-max_line_length = 88
 
 [*.{md,toml,yaml,yml}]
 indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.{py,pyi}]
+indent_size = 4
+indent_style = space
+insert_final_newline = true

--- a/python3-stubs/.github/workflows/pr-build.yml
+++ b/python3-stubs/.github/workflows/pr-build.yml
@@ -13,6 +13,10 @@ on:
 
 jobs:
   test:
-    uses: coatl-dev/workflows/.github/workflows/tox-envs.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/tox.yml@v5
     with:
-      python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+      python-versions: |
+        3.9
+        3.10
+        3.11
+        3.12

--- a/python3-stubs/.github/workflows/{% if upload_registry %}publish.yml{% endif %}.jinja
+++ b/python3-stubs/.github/workflows/{% if upload_registry %}publish.yml{% endif %}.jinja
@@ -7,11 +7,11 @@ on:
 
 jobs:
   tox:
-    uses: coatl-dev/workflows/.github/workflows/tox.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/tox.yml@v5
 
   pypi-publish:
     needs: tox
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v5
     {%- if registry_url != 'https://upload.pypi.org/legacy/' or registry_username != '__token__' %}
     with:
       {%- if registry_url != 'https://upload.pypi.org/legacy/' %}

--- a/python3-stubs/LICENSE.jinja
+++ b/python3-stubs/LICENSE.jinja
@@ -1,4 +1,4 @@
-{%- if project_license == 'Apache Software License' -%}
+{%- if project_license == 'Apache-2.0' -%}
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -200,7 +200,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-{%- elif project_license == 'GNU General Public License v3 (GPLv3)' -%}
+{%- elif project_license == 'GPL-3.0' -%}
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -875,7 +875,7 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <https://www.gnu.org/licenses/why-not-lgpl.html>.
-{%- elif project_license == 'ISC License (ISCL)' -%}
+{%- elif project_license == 'ISC' -%}
 ISC License
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
@@ -891,8 +891,8 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
-{%- elif project_license == 'MIT License' -%}
-MIT License
+{%- elif project_license == 'MIT' -%}
+MIT
 
 Copyright (c) {{ copyright_year }} {{ copyright_holder }}
 

--- a/python3-stubs/pyproject.toml.jinja
+++ b/python3-stubs/pyproject.toml.jinja
@@ -16,15 +16,14 @@ keywords = [
   "scada",
   "stubs",
 ]
-{%- if project_license != 'None' %}license = { file = "LICENSE" }{% endif %}
+license = "{{ project_license }}"
 authors = [ { name = "{{ author_fullname }}", email = "{{ author_email }}" } ]
-requires-python = ">=3.7, <3.13"
+requires-python = ">=3.9, <3.13"
 classifiers = [
   "Development Status :: {{ project_development_status }}",
   "Intended Audience :: Developers",
   "Intended Audience :: Information Technology",
   "Intended Audience :: Manufacturing",
-  {%- if project_license != 'None' %}"License :: OSI Approved :: {{ project_license }}",{% endif %}
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX :: Linux",
@@ -33,8 +32,6 @@ classifiers = [
   {%- endif %}
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
bump coatl-dev/workflows from v4 to v5
python3-stubs: drop Python 3.7 and 3.8

https://packaging.python.org/en/latest/specifications/license-expression/
